### PR TITLE
fix: fix dashboard tabstrib on small resolutions

### DIFF
--- a/src/app/dashboard.style.scss
+++ b/src/app/dashboard.style.scss
@@ -226,7 +226,6 @@ main {
 		overflow: hidden;
 	}
 
-
 	.comp-label {
 		-webkit-user-select: none;
 		-moz-user-select: none;
@@ -278,6 +277,16 @@ main {
 		top: 50%;
 		left: 50%;
 		transform: translate(-50%, -50%);
+	}
+}
+
+@media (max-width: 591px) {
+	.dashboard {
+		.k-tabstrip .k-tabstrip-items {
+			position: relative;
+			top: calc( 1.75em + 6px);
+			font-size: 11px;
+		}
 	}
 }
 


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

* **What is the current behavior?** (You can also link to an open issue here)

Dashboard tabstrib not visible on small resolution

image here: 
![image](https://user-images.githubusercontent.com/8842674/38374377-2283d6c8-38fc-11e8-89f9-db12f37162c0.png)


* **What is the new behavior (if this is a feature change)?**
Fix positioning of the tabstrib on small resolutions only to contain the page and be accessible


* **Other information**:
